### PR TITLE
Fix link to transferstxt

### DIFF
--- a/en/transfers.md
+++ b/en/transfers.md
@@ -1,6 +1,6 @@
 ### transfers.txt
 
-`transfers.transfer_type` can be one of four values [defined in the GTFS](/reference/#transferstxt). These `transfer_type` definitions are quoted from the GTFS Specification below, _in italics_, with additional practice recommendations.
+`transfers.transfer_type` can be one of four values [defined in the GTFS](/reference/static/#transferstxt). These `transfer_type` definitions are quoted from the GTFS Specification below, _in italics_, with additional practice recommendations.
 
 | Field Name | Recommendation |
 | --- | --- |


### PR DESCRIPTION
https://gtfs.org/reference/static/#transferstxt, not https://gtfs.org/reference/#transferstxt